### PR TITLE
Fix invalid package path on Windows

### DIFF
--- a/go.go
+++ b/go.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"runtime"
 	"strings"
 	"text/template"
 )
@@ -55,7 +57,13 @@ func GoCrossCompile(packagePath string, platform Platform, outputTpl string, ldf
 	// directory to build.
 	chdir := ""
 	if packagePath[0] == '_' {
-		chdir = packagePath[1:]
+		if runtime.GOOS == "windows" {
+			re := regexp.MustCompile("^/([a-zA-Z])_/")
+			chdir = re.ReplaceAllString(packagePath[1:], "$1:\\")
+			chdir = strings.Replace(chdir, "/", "\\", -1)
+		} else {
+			chdir = packagePath[1:]
+		}
 		packagePath = ""
 	}
 


### PR DESCRIPTION
I fixed this error.

OS: Windows 8.1 Update 64bit
go version: go1.3.3 windows/386

```
C:\Users\cd01\Desktop\gox-test> gox
Number of parallel builds: 4

-->      darwin/386: _/c_/Users/cd01/Desktop/gox-test
-->    darwin/amd64: _/c_/Users/cd01/Desktop/gox-test
-->       linux/386: _/c_/Users/cd01/Desktop/gox-test
-->     linux/amd64: _/c_/Users/cd01/Desktop/gox-test
-->       linux/arm: _/c_/Users/cd01/Desktop/gox-test
-->     freebsd/386: _/c_/Users/cd01/Desktop/gox-test
-->   freebsd/amd64: _/c_/Users/cd01/Desktop/gox-test
-->     openbsd/386: _/c_/Users/cd01/Desktop/gox-test
-->   openbsd/amd64: _/c_/Users/cd01/Desktop/gox-test
-->     windows/386: _/c_/Users/cd01/Desktop/gox-test
-->   windows/amd64: _/c_/Users/cd01/Desktop/gox-test
-->     freebsd/arm: _/c_/Users/cd01/Desktop/gox-test
-->      netbsd/386: _/c_/Users/cd01/Desktop/gox-test
-->    netbsd/amd64: _/c_/Users/cd01/Desktop/gox-test
-->      netbsd/arm: _/c_/Users/cd01/Desktop/gox-test
-->       plan9/386: _/c_/Users/cd01/Desktop/gox-test
-->   dragonfly/386: _/c_/Users/cd01/Desktop/gox-test
--> dragonfly/amd64: _/c_/Users/cd01/Desktop/gox-test
-->   solaris/amd64: _/c_/Users/cd01/Desktop/gox-test

19 errors occurred:
--> darwin/386 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> darwin/amd64 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> linux/386 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> linux/amd64 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> linux/arm error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> freebsd/386 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> freebsd/amd64 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> openbsd/386 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> openbsd/amd64 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> windows/386 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> windows/amd64 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> freebsd/arm error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> netbsd/386 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> netbsd/amd64 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> netbsd/arm error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> dragonfly/386 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> dragonfly/amd64 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> solaris/amd64 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
--> plan9/386 error: chdir /c_/Users/cd01/Desktop/gox-test: The system cannot find the path specified.
Stderr:
```