### PR TITLE
Add CGO flag, support for plan9/amd64, and some other small bits.

### DIFF
--- a/go.go
+++ b/go.go
@@ -24,7 +24,7 @@ func GoCrossCompile(packagePath string, platform Platform, outputTpl string, ldf
 		"GOOS="+platform.OS,
 		"GOARCH="+platform.Arch)
 	if cgo {
-		env = append(os.Environ(),
+		env = append(env,
 			"CGO_ENABLED=1")
 	}
 

--- a/go.go
+++ b/go.go
@@ -19,10 +19,14 @@ type OutputTemplateData struct {
 }
 
 // GoCrossCompile
-func GoCrossCompile(packagePath string, platform Platform, outputTpl string, ldflags string, tags string) error {
+func GoCrossCompile(packagePath string, platform Platform, outputTpl string, ldflags string, tags string, cgo bool) error {
 	env := append(os.Environ(),
 		"GOOS="+platform.OS,
 		"GOARCH="+platform.Arch)
+	if cgo {
+		env = append(os.Environ(),
+			"CGO_ENABLED=1")
+	}
 
 	var outputPath bytes.Buffer
 	tpl, err := template.New("output").Parse(outputTpl)

--- a/go_test.go
+++ b/go_test.go
@@ -11,7 +11,7 @@ func TestGoVersion(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	acceptable := []string{"devel", "go1.0", "go1.1", "go1.2", "go1.3"}
+	acceptable := []string{"devel", "go1.0", "go1.1", "go1.2", "go1.3", "go1.4"}
 	found := false
 	for _, expected := range acceptable {
 		if strings.HasPrefix(v, expected) {

--- a/main.go
+++ b/main.go
@@ -144,7 +144,7 @@ Options:
   -osarch=""          Space-separated list of os/arch pairs to build for
   -output="foo"       Output path template. See below for more info
   -parallel=-1        Amount of parallelism, defaults to number of CPUs
-  -cgo            	  Enable CGO - required as of 1.4 when there are C files.
+  -cgo                Sets CGO_ENABLED=1 - required as of 1.4 when there are C files.
   -verbose            Verbose mode
 
 Output path template:

--- a/main.go
+++ b/main.go
@@ -22,7 +22,9 @@ func realMain() int {
 	var parallel int
 	var platformFlag PlatformFlag
 	var tags string
+	var cgo bool
 	var verbose bool
+
 	flags := flag.NewFlagSet("gox", flag.ExitOnError)
 	flags.Usage = func() { printUsage() }
 	flags.Var(platformFlag.ArchFlagValue(), "arch", "arch to build for or skip")
@@ -33,6 +35,7 @@ func realMain() int {
 	flags.StringVar(&outputTpl, "output", "{{.Dir}}_{{.OS}}_{{.Arch}}", "output path")
 	flags.IntVar(&parallel, "parallel", -1, "parallelization factor")
 	flags.BoolVar(&buildToolchain, "build-toolchain", false, "build toolchain")
+	flags.BoolVar(&cgo, "cgo", false, "cgo")
 	flags.BoolVar(&verbose, "verbose", false, "verbose")
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		flags.Usage()
@@ -97,7 +100,7 @@ func realMain() int {
 				defer wg.Done()
 				semaphore <- 1
 				fmt.Printf("--> %15s: %s\n", platform.String(), path)
-				if err := GoCrossCompile(path, platform, outputTpl, ldflags, tags); err != nil {
+				if err := GoCrossCompile(path, platform, outputTpl, ldflags, tags, cgo); err != nil {
 					errorLock.Lock()
 					defer errorLock.Unlock()
 					errors = append(errors,
@@ -141,6 +144,7 @@ Options:
   -osarch=""          Space-separated list of os/arch pairs to build for
   -output="foo"       Output path template. See below for more info
   -parallel=-1        Amount of parallelism, defaults to number of CPUs
+  -cgo            	  Enable CGO - required as of 1.4 when there are C files.
   -verbose            Verbose mode
 
 Output path template:

--- a/platform.go
+++ b/platform.go
@@ -61,6 +61,12 @@ var (
 		{"dragonfly", "amd64"},
 		{"solaris", "amd64"},
 	}...)
+
+	// Platforms_1_4 adds support for ARM processors on Android
+	// and Native Client (NaCl) and for AMD64 on Plan 9.
+	Platforms_1_4 = append(Platforms_1_3, []Platform{
+		{"plan9", "amd64"},
+	}...)
 )
 
 // SupportedPlatforms returns the full list of supported platforms for
@@ -70,6 +76,8 @@ func SupportedPlatforms(v string) []Platform {
 		return Platforms_1_0
 	} else if strings.HasPrefix(v, "go1.3") {
 		return Platforms_1_3
+	} else if strings.HasPrefix(v, "go1.4") {
+		return Platforms_1_4
 	}
 
 	return Platforms_1_1

--- a/platform_test.go
+++ b/platform_test.go
@@ -17,4 +17,12 @@ func TestSupportedPlatforms(t *testing.T) {
 	if !reflect.DeepEqual(ps, Platforms_1_1) {
 		t.Fatalf("bad: %#v", ps)
 	}
+	ps = SupportedPlatforms("go1.3")
+	if !reflect.DeepEqual(ps, Platforms_1_3) {
+		t.Fatalf("bad: %#v", ps)
+	}
+	ps = SupportedPlatforms("go1.4")
+	if !reflect.DeepEqual(ps, Platforms_1_4) {
+		t.Fatalf("bad: %#v", ps)
+	}
 }

--- a/toolchain.go
+++ b/toolchain.go
@@ -3,13 +3,14 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/mitchellh/iochan"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sync"
+
+	"github.com/mitchellh/iochan"
 )
 
 // The "main" method for when the toolchain build is requested.
@@ -50,7 +51,7 @@ func mainBuildToolchain(parallel int, platformFlag PlatformFlag, verbose bool) i
 
 	var errorLock sync.Mutex
 	var wg sync.WaitGroup
-	errs := make([]error, 0)
+	var errs []error
 	semaphore := make(chan int, parallel)
 	for _, platform := range platforms {
 		wg.Add(1)


### PR DESCRIPTION
* [Issues #23 #31] Add `-cgo=true` flag to set `CGO_ENABLED=1`
* Update tests to support go 1.4
* Add support for plan9/amd64 which is supported in 1.4
* Fmt toolchain.go and improve declaration of slice of errors

Automatic handling of when to use CGO would probably be better. 

Unfortunately, this doesn't solve the bigger problem in of needing a properly configured cross compiler which is it's own beast of an issue. If your project includes CGO, you are probably better off just compiling off a VM. Open for ideas. Thanks for a great tool @mitchellh 

