### PR TITLE
Support for ARM architectures switches

### DIFF
--- a/go.go
+++ b/go.go
@@ -33,12 +33,20 @@ type CompileOpts struct {
 
 // GoCrossCompile
 func GoCrossCompile(opts *CompileOpts) error {
-	env := append(os.Environ(),
-		"GOOS="+opts.Platform.OS,
-		"GOARCH="+opts.Platform.Arch)
-	if opts.Cgo {
-		env = append(env, "CGO_ENABLED=1")
+	customEnv := make([]string, 0)
+	customEnv = append(customEnv, "GOOS="+opts.Platform.OS)
+	if strings.Index(opts.Platform.Arch, "arm") == 0 {
+		customEnv = append(customEnv,
+			"GOARCH=arm",
+			"GOARM="+opts.Platform.Arch[3:])
+	} else {
+		customEnv = append(customEnv, "GOARCH="+opts.Platform.Arch)
 	}
+	if opts.Cgo {
+		customEnv = append(customEnv, "CGO_ENABLED=1")
+	}
+
+	env := append(os.Environ(), customEnv...)
 
 	var outputPath bytes.Buffer
 	tpl, err := template.New("output").Parse(opts.OutputTpl)
@@ -183,6 +191,7 @@ func execGo(env []string, dir string, args ...string) (string, error) {
 	if dir != "" {
 		cmd.Dir = dir
 	}
+
 	if err := cmd.Run(); err != nil {
 		err = fmt.Errorf("%s\nStderr: %s", err, stderr.String())
 		return "", err

--- a/go_test.go
+++ b/go_test.go
@@ -12,7 +12,7 @@ func TestGoVersion(t *testing.T) {
 	}
 
 	acceptable := []string{
-		"devel", "go1.0", "go1.1", "go1.2", "go1.3", "go1.4.2",
+		"devel", "go1.0", "go1.1", "go1.2", "go1.3", "go1.4.1", "go1.4.2",
 	}
 	found := false
 	for _, expected := range acceptable {

--- a/platform.go
+++ b/platform.go
@@ -46,7 +46,9 @@ var (
 		{"darwin", "amd64", true},
 		{"linux", "386", true},
 		{"linux", "amd64", true},
-		{"linux", "arm", true},
+		{"linux", "arm5", false},
+		{"linux", "arm6", true},
+		{"linux", "arm7", false},
 		{"freebsd", "386", true},
 		{"freebsd", "amd64", true},
 		{"openbsd", "386", true},
@@ -56,10 +58,14 @@ var (
 	}
 
 	Platforms_1_1 = append(Platforms_1_0, []Platform{
-		{"freebsd", "arm", true},
+		{"freebsd", "arm5", false},
+		{"freebsd", "arm6", true},
+		{"freebsd", "arm7", false},
 		{"netbsd", "386", true},
 		{"netbsd", "amd64", true},
-		{"netbsd", "arm", true},
+		{"netbsd", "arm5", false},
+		{"netbsd", "arm6", true},
+		{"netbsd", "arm7", false},
 		{"plan9", "386", false},
 	}...)
 
@@ -68,12 +74,16 @@ var (
 		{"dragonfly", "amd64", false},
 		{"nacl", "amd64", false},
 		{"nacl", "amd64p32", false},
-		{"nacl", "arm", false},
+		{"nacl", "arm5", false},
+		{"nacl", "arm6", false},
+		{"nacl", "arm7", false},
 		{"solaris", "amd64", false},
 	}...)
 
 	Platforms_1_4 = append(Platforms_1_3, []Platform{
-		{"android", "arm", false},
+		{"android", "arm5", false},
+		{"android", "arm6", false},
+		{"android", "arm7", false},
 		{"plan9", "amd64", false},
 	}...)
 )


### PR DESCRIPTION
I am a beginner in ARM, building as a first project some multi-server management utility to fill the holes I see with Chef. All my home servers are ARM (NAS is DS413j with ARM5, Raspberry Pis are using ARM6, RadxaRockPros with ARM7), and your build utility gox came to my attention, but since each of these servers demand a different target binary, as described in page https://github.com/golang/go/wiki/GoArm.
Anyway I have it working with my fork, I hope you don't find any blocking issue for the merge.
P.S. I added support for 1.4.1 since 1.4.2 introduced a ARMv5 instruction problem (illegal binaries are being built).