### PR TITLE
Use cpus-1 instead of maxing out

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,9 +46,14 @@ func realMain() int {
 	}
 
 	// Determine what amount of parallelism we want Default to the current
-	// number of CPUs is <= 0 is specified.
+	// number of CPUs-1 is <= 0 is specified.
 	if parallel <= 0 {
-		parallel = runtime.NumCPU()
+		cpus := runtime.NumCPU()
+		if cpus < 2 {
+			parallel = 1
+		} else {
+			parallel = cpus - 1
+		}
 	}
 
 	if buildToolchain {


### PR DESCRIPTION
I don't fully understand why, but the Bundler team found the same thing when implementing parallel downloads in bundler. CPUS-1 is _faster_ than maxing out all the CPUS:

```text
# Maxed (8)
make bin  515.53s user 61.09s system 694% cpu 

# Maxed-1 (7)
make bin  503.97s user 59.54s system 658% cpu 
```