### PR TITLE
Fail if no valid platforms found

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func realMain() int {
 		fmt.Println("No valid platforms to build for. If you specified a value")
 		fmt.Println("for the 'os', 'arch', or 'osarch' flags, make sure you're")
 		fmt.Println("using a valid value.")
-		return 0
+		return 1
 	}
 
 	// Build in parallel!


### PR DESCRIPTION
I had a typo in a build script that passed in a bad arch value, and I was surprised to see that my script continued running even though gox failed.