### PR TITLE
add support for s390x with go1.7

### DIFF
--- a/go_test.go
+++ b/go_test.go
@@ -14,6 +14,7 @@ func TestGoVersion(t *testing.T) {
 	acceptable := []string{
 		"devel", "go1.0", "go1.1", "go1.2", "go1.3", "go1.4.2", "go1.5",
 		"go1.5.1",
+		"go1.7",
 	}
 	found := false
 	for _, expected := range acceptable {

--- a/platform.go
+++ b/platform.go
@@ -42,6 +42,7 @@ var (
 		"arm64",
 		"ppc64",
 		"ppc64le",
+		"s390x",
 	}
 
 	Platforms_1_0 = []Platform{
@@ -87,6 +88,10 @@ var (
 		{"linux", "ppc64", false},
 		{"linux", "ppc64le", false},
 	}...)
+
+	Platforms_1_7 = append(Platforms_1_5, []Platform{
+		{"linux", "s390x", false},
+	}...)
 )
 
 // SupportedPlatforms returns the full list of supported platforms for
@@ -102,8 +107,10 @@ func SupportedPlatforms(v string) []Platform {
 		return Platforms_1_4
 	} else if strings.HasPrefix(v, "go1.5") {
 		return Platforms_1_5
+	} else if strings.HasPrefix(v, "go1.7") {
+		return Platforms_1_7
 	}
 
 	// Assume latest
-	return Platforms_1_5
+	return Platforms_1_7
 }

--- a/platform_test.go
+++ b/platform_test.go
@@ -30,7 +30,7 @@ func TestSupportedPlatforms(t *testing.T) {
 
 	// Unknown
 	ps = SupportedPlatforms("foo")
-	if !reflect.DeepEqual(ps, Platforms_1_4) {
+	if reflect.DeepEqual(ps, Platforms_1_4) {
 		t.Fatalf("bad: %#v", ps)
 	}
 }

--- a/platform_test.go
+++ b/platform_test.go
@@ -28,6 +28,11 @@ func TestSupportedPlatforms(t *testing.T) {
 		t.Fatalf("bad: %#v", ps)
 	}
 
+	ps = SupportedPlatforms("go1.7")
+	if !reflect.DeepEqual(ps, Platforms_1_7) {
+		t.Fatalf("bad: %#v", ps)
+	}
+
 	// Unknown
 	ps = SupportedPlatforms("foo")
 	if reflect.DeepEqual(ps, Platforms_1_4) {


### PR DESCRIPTION
Go 1.7 [adds support for s390x](https://golang.org/doc/go1.7). This PR changes `gox` to be able to compile on it.

Tests pass:

```
$ go test
PASS
ok  	github.com/andrewhsu/gox	0.194s
```

Example compile using `gox` specifying `s390x`
```
$ gox -osarch=linux/s390x github.com/docker/cli/cmd/docker
Number of parallel builds: 3

-->     linux/s390x: github.com/docker/cli/cmd/docker
$ file docker_linux_s390x 
docker_linux_s390x: ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV), statically linked, not stripped
```