### PR TITLE
Unset $GOOS and $GOARCH before setting

### DIFF
--- a/go.go
+++ b/go.go
@@ -34,6 +34,8 @@ type CompileOpts struct {
 
 // GoCrossCompile
 func GoCrossCompile(opts *CompileOpts) error {
+	os.Unsetenv("GOOS")
+	os.Unsetenv("GOARCH")
 	env := append(os.Environ(),
 		"GOOS="+opts.Platform.OS,
 		"GOARCH="+opts.Platform.Arch)


### PR DESCRIPTION
This PR fixes an issue I found when I was working on my project [sha3sum](https://github.com/Equim-chan/sha3sum).

tl;dr `go generate` injects env $GOOS and $GOARCH, leading to this issue.

The reproduction of the issue is as following:

$GOPATH/src tree:
```
src
|
\---gox-issue
    |   main.go
    |
    \---builder
            main.go
```

$GOPATH/src/gox-issue/main.go:
```go
package main

//go:generate go run $GOPATH/src/gox-issue/builder/main.go

import (
	"fmt"
	"runtime"
)

func main() {
	fmt.Println("runtime.GOOS:" + runtime.GOOS)
	fmt.Println("runtime.GOARCH:" + runtime.GOARCH)
	fmt.Println("This should not happen.")
}
```

$GOPATH/src/gox-issue/build/main.go:
```go
package main

import (
	"fmt"
	"os"
	"os/exec"
)

func main() {
	fmt.Println("Env of the builder:")
	fmt.Println("GOOS=" + os.Getenv("GOOS"))
	fmt.Println("GOARCH=" + os.Getenv("GOARCH"))

	cmd := exec.Command("gox", "gox-issue")
	cmd.Stdout = os.Stdout
	cmd.Stderr = os.Stderr
	if err := cmd.Run(); err != nil {
		fmt.Fprintln(os.Stderr, err)
	}
}
```

Now we do:
```
$ cd $GOPATH/src/gox-issue
$ go generate
Env of the builder:
GOOS=linux
GOARCH=amd64
Number of parallel builds: 2

-->      netbsd/arm: gox-issue
-->   freebsd/amd64: gox-issue
-->   windows/amd64: gox-issue
-->     openbsd/386: gox-issue
-->   openbsd/amd64: gox-issue
-->     windows/386: gox-issue
-->       linux/386: gox-issue
-->      darwin/386: gox-issue
-->    darwin/amd64: gox-issue
-->      netbsd/386: gox-issue
-->     freebsd/arm: gox-issue
-->    netbsd/amd64: gox-issue
-->       linux/arm: gox-issue
-->     linux/amd64: gox-issue
-->     freebsd/386: gox-issue
```

And the issue shows up:
```
$ sha1sum gox-issue*
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_darwin_386
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_darwin_amd64
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_freebsd_386
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_freebsd_amd64
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_freebsd_arm
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_linux_386
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_linux_amd64
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_linux_arm
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_netbsd_386
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_netbsd_amd64
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_netbsd_arm
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_openbsd_386
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_openbsd_amd64
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_windows_386.exe
c99c023d6dc39b71db614dd8600a4185713fdaba  gox-issue_windows_amd64.exe
$ ./gox-issue_windows_386.exe
runtime.GOOS:linux
runtime.GOARCH:amd64
This should not happen.
```