### PR TITLE
Add the packaging metadata to build the gox snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: gox
+version: master
+summary:
+  A dead simple, no frills Go cross compile tool
+description: |
+  Gox is a simple, no-frills tool for Go cross compilation that behaves a lot
+  like standard go build. Gox will parallelize builds for multiple platforms.
+  Gox will also build the cross-compilation toolchain for you.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: classic
+
+apps:
+  gox:
+    command: bin/gox
+    plugs: [home]
+
+parts:
+  gox:
+    source: .
+    plugin: go
+    go-importpath: github.com/mitchellh/gox

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,6 @@ confinement: classic
 apps:
   gox:
     command: bin/gox
-    plugs: [home]
 
 parts:
   gox:


### PR DESCRIPTION
This package will let you publish the latest gox in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.