### PR TITLE
Add go_import_path to travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ go:
 
 script:
   - go test ./...
+
+go_import_path: github.com/mitchellh/gox


### PR DESCRIPTION
This makes sure if a fork runs travis on the build, it also works. For more details see https://docs.travis-ci.com/user/languages/go/#Go-Import-Path