### PR TITLE
Fix -gcflags

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,6 +129,7 @@ func realMain() int {
 					Platform:    platform,
 					OutputTpl:   outputTpl,
 					Ldflags:     ldflags,
+					Gcflags:     flagGcflags,
 					Tags:        tags,
 					Cgo:         flagCgo,
 					Rebuild:     flagRebuild,


### PR DESCRIPTION
The -gcflags option from the command line was not applied.