### PR TITLE
Support for -race flag [fixes #104]

### DIFF
--- a/go.go
+++ b/go.go
@@ -28,6 +28,7 @@ type CompileOpts struct {
 	Gcflags     string
 	Asmflags    string
 	Tags        string
+	Raceflag    bool
 	Cgo         bool
 	Rebuild     bool
 	GoCmd       string
@@ -106,6 +107,9 @@ func GoCrossCompile(opts *CompileOpts) error {
 	args := []string{"build"}
 	if opts.Rebuild {
 		args = append(args, "-a")
+	}
+	if opts.Raceflag {
+		args = append(args, "-race")
 	}
 	args = append(args,
 		"-gcflags", opts.Gcflags,

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func realMain() int {
 	var tags string
 	var verbose bool
 	var flagGcflags, flagAsmflags string
-	var flagCgo, flagRebuild, flagListOSArch bool
+	var flagCgo, flagRebuild, flagRaceflag, flagListOSArch bool
 	var flagGoCmd string
 	flags := flag.NewFlagSet("gox", flag.ExitOnError)
 	flags.Usage = func() { printUsage() }
@@ -39,6 +39,7 @@ func realMain() int {
 	flags.BoolVar(&verbose, "verbose", false, "verbose")
 	flags.BoolVar(&flagCgo, "cgo", false, "")
 	flags.BoolVar(&flagRebuild, "rebuild", false, "")
+	flags.BoolVar(&flagRaceflag, "race", false, "")
 	flags.BoolVar(&flagListOSArch, "osarch-list", false, "")
 	flags.StringVar(&flagGcflags, "gcflags", "", "")
 	flags.StringVar(&flagAsmflags, "asmflags", "", "")
@@ -133,6 +134,7 @@ func realMain() int {
 					Gcflags:     flagGcflags,
 					Asmflags:    flagAsmflags,
 					Tags:        tags,
+					Raceflag:    flagRaceflag,
 					Cgo:         flagCgo,
 					Rebuild:     flagRebuild,
 					GoCmd:       flagGoCmd,
@@ -187,6 +189,7 @@ Options:
   -ldflags=""         Additional '-ldflags' value to pass to go build
   -asmflags=""        Additional '-asmflags' value to pass to go build
   -tags=""            Additional '-tags' value to pass to go build
+  -race               Additional '-race' value to pass to go build
   -os=""              Space-separated list of operating systems to build for
   -osarch=""          Space-separated list of os/arch pairs to build for
   -osarch-list        List supported os/arch pairs for your Go version


### PR DESCRIPTION
Introduces the `-race` flag that is passed on to `go`. In cases where the architecture or OS doesn't support the flag, Go will come back with a clean error message.