### PR TITLE
Use structured version checking.

### DIFF
--- a/platform_test.go
+++ b/platform_test.go
@@ -18,6 +18,11 @@ func TestSupportedPlatforms(t *testing.T) {
 		t.Fatalf("bad: %#v", ps)
 	}
 
+	ps = SupportedPlatforms("go1.2")
+	if !reflect.DeepEqual(ps, Platforms_1_1) {
+		t.Fatalf("bad: %#v", ps)
+	}
+
 	ps = SupportedPlatforms("go1.3")
 	if !reflect.DeepEqual(ps, Platforms_1_3) {
 		t.Fatalf("bad: %#v", ps)

--- a/vendor/github.com/hashicorp/go-version/LICENSE
+++ b/vendor/github.com/hashicorp/go-version/LICENSE
@@ -1,0 +1,354 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. “Contributor”
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. “Contributor Version”
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor’s Contribution.
+
+1.3. “Contribution”
+
+     means Covered Software of a particular Contributor.
+
+1.4. “Covered Software”
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. “Incompatible With Secondary Licenses”
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of version
+        1.1 or earlier of the License, but not also under the terms of a
+        Secondary License.
+
+1.6. “Executable Form”
+
+     means any form of the work other than Source Code Form.
+
+1.7. “Larger Work”
+
+     means a work that combines Covered Software with other material, in a separate
+     file or files, that is not Covered Software.
+
+1.8. “License”
+
+     means this document.
+
+1.9. “Licensable”
+
+     means having the right to grant, to the maximum extent possible, whether at the
+     time of the initial grant or subsequently, any and all of the rights conveyed by
+     this License.
+
+1.10. “Modifications”
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to, deletion
+        from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. “Patent Claims” of a Contributor
+
+      means any patent claim(s), including without limitation, method, process,
+      and apparatus claims, in any patent Licensable by such Contributor that
+      would be infringed, but for the grant of the License, by the making,
+      using, selling, offering for sale, having made, import, or transfer of
+      either its Contributions or its Contributor Version.
+
+1.12. “Secondary License”
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. “Source Code Form”
+
+      means the form of the work preferred for making modifications.
+
+1.14. “You” (or “Your”)
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, “You” includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, “control” means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or as
+        part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its Contributions
+        or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution become
+     effective for each Contribution on the date the Contributor first distributes
+     such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under this
+     License. No additional rights or licenses will be implied from the distribution
+     or licensing of Covered Software under this License. Notwithstanding Section
+     2.1(b) above, no patent license is granted by a Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party’s
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of its
+        Contributions.
+
+     This License does not grant any rights in the trademarks, service marks, or
+     logos of any Contributor (except as may be necessary to comply with the
+     notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this License
+     (see Section 10.2) or under the terms of a Secondary License (if permitted
+     under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its Contributions
+     are its original creation(s) or it has sufficient rights to grant the
+     rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under applicable
+     copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under the
+     terms of this License. You must inform recipients that the Source Code Form
+     of the Covered Software is governed by the terms of this License, and how
+     they can obtain a copy of this License. You may not attempt to alter or
+     restrict the recipients’ rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this License,
+        or sublicense it under different terms, provided that the license for
+        the Executable Form does not attempt to limit or alter the recipients’
+        rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for the
+     Covered Software. If the Larger Work is a combination of Covered Software
+     with a work governed by one or more Secondary Licenses, and the Covered
+     Software is not Incompatible With Secondary Licenses, this License permits
+     You to additionally distribute such Covered Software under the terms of
+     such Secondary License(s), so that the recipient of the Larger Work may, at
+     their option, further distribute the Covered Software under the terms of
+     either this License or such Secondary License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices (including
+     copyright notices, patent notices, disclaimers of warranty, or limitations
+     of liability) contained within the Source Code Form of the Covered
+     Software, except that You may alter any license notices to the extent
+     required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on behalf
+     of any Contributor. You must make it absolutely clear that any such
+     warranty, support, indemnity, or liability obligation is offered by You
+     alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute, judicial
+   order, or regulation then You must: (a) comply with the terms of this License
+   to the maximum extent possible; and (b) describe the limitations and the code
+   they affect. Such description must be placed in a text file included with all
+   distributions of the Covered Software under this License. Except to the
+   extent prohibited by statute or regulation, such description must be
+   sufficiently detailed for a recipient of ordinary skill to be able to
+   understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+     if such Contributor fails to notify You of the non-compliance by some
+     reasonable means prior to 60 days after You have come back into compliance.
+     Moreover, Your grants from a particular Contributor are reinstated on an
+     ongoing basis if such Contributor notifies You of the non-compliance by
+     some reasonable means, this is the first time You have received notice of
+     non-compliance with this License from such Contributor, and You become
+     compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions, counter-claims,
+     and cross-claims) alleging that a Contributor Version directly or
+     indirectly infringes any patent, then the rights granted to You by any and
+     all Contributors for the Covered Software under Section 2.1 of this License
+     shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an “as is” basis, without
+   warranty of any kind, either expressed, implied, or statutory, including,
+   without limitation, warranties that the Covered Software is free of defects,
+   merchantable, fit for a particular purpose or non-infringing. The entire
+   risk as to the quality and performance of the Covered Software is with You.
+   Should any Covered Software prove defective in any respect, You (not any
+   Contributor) assume the cost of any necessary servicing, repair, or
+   correction. This disclaimer of warranty constitutes an essential part of this
+   License. No use of  any Covered Software is authorized under this License
+   except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from such
+   party’s negligence to the extent applicable law prohibits such limitation.
+   Some jurisdictions do not allow the exclusion or limitation of incidental or
+   consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts of
+   a jurisdiction where the defendant maintains its principal place of business
+   and such litigation shall be governed by laws of that jurisdiction, without
+   reference to its conflict-of-law provisions. Nothing in this Section shall
+   prevent a party’s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject matter
+   hereof. If any provision of this License is held to be unenforceable, such
+   provision shall be reformed only to the extent necessary to make it
+   enforceable. Any law or regulation which provides that the language of a
+   contract shall be construed against the drafter shall not be used to construe
+   this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version of
+      the License under which You originally received the Covered Software, or
+      under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a modified
+      version of this License if you rename the license and remove any
+      references to the name of the license steward (except to note that such
+      modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+      If You choose to distribute Source Code Form that is Incompatible With
+      Secondary Licenses under the terms of this version of the License, the
+      notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then
+You may include the notice in a location (such as a LICENSE file in a relevant
+directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+      This Source Code Form is “Incompatible
+      With Secondary Licenses”, as defined by
+      the Mozilla Public License, v. 2.0.
+

--- a/vendor/github.com/hashicorp/go-version/README.md
+++ b/vendor/github.com/hashicorp/go-version/README.md
@@ -1,0 +1,65 @@
+# Versioning Library for Go
+[![Build Status](https://travis-ci.org/hashicorp/go-version.svg?branch=master)](https://travis-ci.org/hashicorp/go-version)
+
+go-version is a library for parsing versions and version constraints,
+and verifying versions against a set of constraints. go-version
+can sort a collection of versions properly, handles prerelease/beta
+versions, can increment versions, etc.
+
+Versions used with go-version must follow [SemVer](http://semver.org/).
+
+## Installation and Usage
+
+Package documentation can be found on
+[GoDoc](http://godoc.org/github.com/hashicorp/go-version).
+
+Installation can be done with a normal `go get`:
+
+```
+$ go get github.com/hashicorp/go-version
+```
+
+#### Version Parsing and Comparison
+
+```go
+v1, err := version.NewVersion("1.2")
+v2, err := version.NewVersion("1.5+metadata")
+
+// Comparison example. There is also GreaterThan, Equal, and just
+// a simple Compare that returns an int allowing easy >=, <=, etc.
+if v1.LessThan(v2) {
+    fmt.Printf("%s is less than %s", v1, v2)
+}
+```
+
+#### Version Constraints
+
+```go
+v1, err := version.NewVersion("1.2")
+
+// Constraints example.
+constraints, err := version.NewConstraint(">= 1.0, < 1.4")
+if constraints.Check(v1) {
+	fmt.Printf("%s satisfies constraints %s", v1, constraints)
+}
+```
+
+#### Version Sorting
+
+```go
+versionsRaw := []string{"1.1", "0.7.1", "1.4-beta", "1.4", "2"}
+versions := make([]*version.Version, len(versionsRaw))
+for i, raw := range versionsRaw {
+    v, _ := version.NewVersion(raw)
+    versions[i] = v
+}
+
+// After this, the versions are properly sorted
+sort.Sort(version.Collection(versions))
+```
+
+## Issues and Contributing
+
+If you find an issue with this library, please report an issue. If you'd
+like, we welcome any contributions. Fork this library and submit a pull
+request.

--- a/vendor/github.com/hashicorp/go-version/constraint.go
+++ b/vendor/github.com/hashicorp/go-version/constraint.go
@@ -1,0 +1,178 @@
+package version
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Constraint represents a single constraint for a version, such as
+// ">= 1.0".
+type Constraint struct {
+	f        constraintFunc
+	check    *Version
+	original string
+}
+
+// Constraints is a slice of constraints. We make a custom type so that
+// we can add methods to it.
+type Constraints []*Constraint
+
+type constraintFunc func(v, c *Version) bool
+
+var constraintOperators map[string]constraintFunc
+
+var constraintRegexp *regexp.Regexp
+
+func init() {
+	constraintOperators = map[string]constraintFunc{
+		"":   constraintEqual,
+		"=":  constraintEqual,
+		"!=": constraintNotEqual,
+		">":  constraintGreaterThan,
+		"<":  constraintLessThan,
+		">=": constraintGreaterThanEqual,
+		"<=": constraintLessThanEqual,
+		"~>": constraintPessimistic,
+	}
+
+	ops := make([]string, 0, len(constraintOperators))
+	for k := range constraintOperators {
+		ops = append(ops, regexp.QuoteMeta(k))
+	}
+
+	constraintRegexp = regexp.MustCompile(fmt.Sprintf(
+		`^\s*(%s)\s*(%s)\s*$`,
+		strings.Join(ops, "|"),
+		VersionRegexpRaw))
+}
+
+// NewConstraint will parse one or more constraints from the given
+// constraint string. The string must be a comma-separated list of
+// constraints.
+func NewConstraint(v string) (Constraints, error) {
+	vs := strings.Split(v, ",")
+	result := make([]*Constraint, len(vs))
+	for i, single := range vs {
+		c, err := parseSingle(single)
+		if err != nil {
+			return nil, err
+		}
+
+		result[i] = c
+	}
+
+	return Constraints(result), nil
+}
+
+// Check tests if a version satisfies all the constraints.
+func (cs Constraints) Check(v *Version) bool {
+	for _, c := range cs {
+		if !c.Check(v) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Returns the string format of the constraints
+func (cs Constraints) String() string {
+	csStr := make([]string, len(cs))
+	for i, c := range cs {
+		csStr[i] = c.String()
+	}
+
+	return strings.Join(csStr, ",")
+}
+
+// Check tests if a constraint is validated by the given version.
+func (c *Constraint) Check(v *Version) bool {
+	return c.f(v, c.check)
+}
+
+func (c *Constraint) String() string {
+	return c.original
+}
+
+func parseSingle(v string) (*Constraint, error) {
+	matches := constraintRegexp.FindStringSubmatch(v)
+	if matches == nil {
+		return nil, fmt.Errorf("Malformed constraint: %s", v)
+	}
+
+	check, err := NewVersion(matches[2])
+	if err != nil {
+		return nil, err
+	}
+
+	return &Constraint{
+		f:        constraintOperators[matches[1]],
+		check:    check,
+		original: v,
+	}, nil
+}
+
+//-------------------------------------------------------------------
+// Constraint functions
+//-------------------------------------------------------------------
+
+func constraintEqual(v, c *Version) bool {
+	return v.Equal(c)
+}
+
+func constraintNotEqual(v, c *Version) bool {
+	return !v.Equal(c)
+}
+
+func constraintGreaterThan(v, c *Version) bool {
+	return v.Compare(c) == 1
+}
+
+func constraintLessThan(v, c *Version) bool {
+	return v.Compare(c) == -1
+}
+
+func constraintGreaterThanEqual(v, c *Version) bool {
+	return v.Compare(c) >= 0
+}
+
+func constraintLessThanEqual(v, c *Version) bool {
+	return v.Compare(c) <= 0
+}
+
+func constraintPessimistic(v, c *Version) bool {
+	// If the version being checked is naturally less than the constraint, then there
+	// is no way for the version to be valid against the constraint
+	if v.LessThan(c) {
+		return false
+	}
+	// We'll use this more than once, so grab the length now so it's a little cleaner
+	// to write the later checks
+	cs := len(c.segments)
+
+	// If the version being checked has less specificity than the constraint, then there
+	// is no way for the version to be valid against the constraint
+	if cs > len(v.segments) {
+		return false
+	}
+
+	// Check the segments in the constraint against those in the version. If the version
+	// being checked, at any point, does not have the same values in each index of the
+	// constraints segments, then it cannot be valid against the constraint.
+	for i := 0; i < c.si-1; i++ {
+		if v.segments[i] != c.segments[i] {
+			return false
+		}
+	}
+
+	// Check the last part of the segment in the constraint. If the version segment at
+	// this index is less than the constraints segment at this index, then it cannot
+	// be valid against the constraint
+	if c.segments[cs-1] > v.segments[cs-1] {
+		return false
+	}
+
+	// If nothing has rejected the version by now, it's valid
+	return true
+}

--- a/vendor/github.com/hashicorp/go-version/constraint_test.go
+++ b/vendor/github.com/hashicorp/go-version/constraint_test.go
@@ -1,0 +1,113 @@
+package version
+
+import (
+	"testing"
+)
+
+func TestNewConstraint(t *testing.T) {
+	cases := []struct {
+		input string
+		count int
+		err   bool
+	}{
+		{">= 1.2", 1, false},
+		{"1.0", 1, false},
+		{">= 1.x", 0, true},
+		{">= 1.2, < 1.0", 2, false},
+
+		// Out of bounds
+		{"11387778780781445675529500000000000000000", 0, true},
+	}
+
+	for _, tc := range cases {
+		v, err := NewConstraint(tc.input)
+		if tc.err && err == nil {
+			t.Fatalf("expected error for input: %s", tc.input)
+		} else if !tc.err && err != nil {
+			t.Fatalf("error for input %s: %s", tc.input, err)
+		}
+
+		if len(v) != tc.count {
+			t.Fatalf("input: %s\nexpected len: %d\nactual: %d",
+				tc.input, tc.count, len(v))
+		}
+	}
+}
+
+func TestConstraintCheck(t *testing.T) {
+	cases := []struct {
+		constraint string
+		version    string
+		check      bool
+	}{
+		{">= 1.0, < 1.2", "1.1.5", true},
+		{"< 1.0, < 1.2", "1.1.5", false},
+		{"= 1.0", "1.1.5", false},
+		{"= 1.0", "1.0.0", true},
+		{"1.0", "1.0.0", true},
+		{"~> 1.0", "2.0", false},
+		{"~> 1.0", "1.1", true},
+		{"~> 1.0", "1.2.3", true},
+		{"~> 1.0.0", "1.2.3", false},
+		{"~> 1.0.0", "1.0.7", true},
+		{"~> 1.0.0", "1.1.0", false},
+		{"~> 1.0.7", "1.0.4", false},
+		{"~> 1.0.7", "1.0.7", true},
+		{"~> 1.0.7", "1.0.8", true},
+		{"~> 1.0.7", "1.0.7.5", true},
+		{"~> 1.0.7", "1.0.6.99", false},
+		{"~> 1.0.7", "1.0.8.0", true},
+		{"~> 1.0.9.5", "1.0.9.5", true},
+		{"~> 1.0.9.5", "1.0.9.4", false},
+		{"~> 1.0.9.5", "1.0.9.6", true},
+		{"~> 1.0.9.5", "1.0.9.5.0", true},
+		{"~> 1.0.9.5", "1.0.9.5.1", true},
+	}
+
+	for _, tc := range cases {
+		c, err := NewConstraint(tc.constraint)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		actual := c.Check(v)
+		expected := tc.check
+		if actual != expected {
+			t.Fatalf("Version: %s\nConstraint: %s\nExpected: %#v",
+				tc.version, tc.constraint, expected)
+		}
+	}
+}
+
+func TestConstraintsString(t *testing.T) {
+	cases := []struct {
+		constraint string
+		result     string
+	}{
+		{">= 1.0, < 1.2", ""},
+		{"~> 1.0.7", ""},
+	}
+
+	for _, tc := range cases {
+		c, err := NewConstraint(tc.constraint)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		actual := c.String()
+		expected := tc.result
+		if expected == "" {
+			expected = tc.constraint
+		}
+
+		if actual != expected {
+			t.Fatalf("Constraint: %s\nExpected: %#v\nActual: %s",
+				tc.constraint, expected, actual)
+		}
+	}
+}

--- a/vendor/github.com/hashicorp/go-version/version.go
+++ b/vendor/github.com/hashicorp/go-version/version.go
@@ -1,0 +1,326 @@
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// The compiled regular expression used to test the validity of a version.
+var versionRegexp *regexp.Regexp
+
+// The raw regular expression string used for testing the validity
+// of a version.
+const VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
+	`(-?([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
+	`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
+	`?`
+
+// Version represents a single version.
+type Version struct {
+	metadata string
+	pre      string
+	segments []int64
+	si       int
+}
+
+func init() {
+	versionRegexp = regexp.MustCompile("^" + VersionRegexpRaw + "$")
+}
+
+// NewVersion parses the given version and returns a new
+// Version.
+func NewVersion(v string) (*Version, error) {
+	matches := versionRegexp.FindStringSubmatch(v)
+	if matches == nil {
+		return nil, fmt.Errorf("Malformed version: %s", v)
+	}
+	segmentsStr := strings.Split(matches[1], ".")
+	segments := make([]int64, len(segmentsStr))
+	si := 0
+	for i, str := range segmentsStr {
+		val, err := strconv.ParseInt(str, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Error parsing version: %s", err)
+		}
+
+		segments[i] = int64(val)
+		si++
+	}
+
+	// Even though we could support more than three segments, if we
+	// got less than three, pad it with 0s. This is to cover the basic
+	// default usecase of semver, which is MAJOR.MINOR.PATCH at the minimum
+	for i := len(segments); i < 3; i++ {
+		segments = append(segments, 0)
+	}
+
+	return &Version{
+		metadata: matches[7],
+		pre:      matches[4],
+		segments: segments,
+		si:       si,
+	}, nil
+}
+
+// Must is a helper that wraps a call to a function returning (*Version, error)
+// and panics if error is non-nil.
+func Must(v *Version, err error) *Version {
+	if err != nil {
+		panic(err)
+	}
+
+	return v
+}
+
+// Compare compares this version to another version. This
+// returns -1, 0, or 1 if this version is smaller, equal,
+// or larger than the other version, respectively.
+//
+// If you want boolean results, use the LessThan, Equal,
+// or GreaterThan methods.
+func (v *Version) Compare(other *Version) int {
+	// A quick, efficient equality check
+	if v.String() == other.String() {
+		return 0
+	}
+
+	segmentsSelf := v.Segments64()
+	segmentsOther := other.Segments64()
+
+	// If the segments are the same, we must compare on prerelease info
+	if reflect.DeepEqual(segmentsSelf, segmentsOther) {
+		preSelf := v.Prerelease()
+		preOther := other.Prerelease()
+		if preSelf == "" && preOther == "" {
+			return 0
+		}
+		if preSelf == "" {
+			return 1
+		}
+		if preOther == "" {
+			return -1
+		}
+
+		return comparePrereleases(preSelf, preOther)
+	}
+
+	// Get the highest specificity (hS), or if they're equal, just use segmentSelf length
+	lenSelf := len(segmentsSelf)
+	lenOther := len(segmentsOther)
+	hS := lenSelf
+	if lenSelf < lenOther {
+		hS = lenOther
+	}
+	// Compare the segments
+	// Because a constraint could have more/less specificity than the version it's
+	// checking, we need to account for a lopsided or jagged comparison
+	for i := 0; i < hS; i++ {
+		if i > lenSelf-1 {
+			// This means Self had the lower specificity
+			// Check to see if the remaining segments in Other are all zeros
+			if !allZero(segmentsOther[i:]) {
+				// if not, it means that Other has to be greater than Self
+				return -1
+			}
+			break
+		} else if i > lenOther-1 {
+			// this means Other had the lower specificity
+			// Check to see if the remaining segments in Self are all zeros -
+			if !allZero(segmentsSelf[i:]) {
+				//if not, it means that Self has to be greater than Other
+				return 1
+			}
+			break
+		}
+		lhs := segmentsSelf[i]
+		rhs := segmentsOther[i]
+		if lhs == rhs {
+			continue
+		} else if lhs < rhs {
+			return -1
+		}
+		// Otherwis, rhs was > lhs, they're not equal
+		return 1
+	}
+
+	// if we got this far, they're equal
+	return 0
+}
+
+func allZero(segs []int64) bool {
+	for _, s := range segs {
+		if s != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func comparePart(preSelf string, preOther string) int {
+	if preSelf == preOther {
+		return 0
+	}
+
+	var selfInt int64
+	selfNumeric := true
+	selfInt, err := strconv.ParseInt(preSelf, 10, 64)
+	if err != nil {
+		selfNumeric = false
+	}
+
+	var otherInt int64
+	otherNumeric := true
+	otherInt, err = strconv.ParseInt(preOther, 10, 64)
+	if err != nil {
+		otherNumeric = false
+	}
+
+	// if a part is empty, we use the other to decide
+	if preSelf == "" {
+		if otherNumeric {
+			return -1
+		}
+		return 1
+	}
+
+	if preOther == "" {
+		if selfNumeric {
+			return 1
+		}
+		return -1
+	}
+
+	if selfNumeric && !otherNumeric {
+		return -1
+	} else if !selfNumeric && otherNumeric {
+		return 1
+	} else if !selfNumeric && !otherNumeric && preSelf > preOther {
+		return 1
+	} else if selfInt > otherInt {
+		return 1
+	}
+
+	return -1
+}
+
+func comparePrereleases(v string, other string) int {
+	// the same pre release!
+	if v == other {
+		return 0
+	}
+
+	// split both pre releases for analyse their parts
+	selfPreReleaseMeta := strings.Split(v, ".")
+	otherPreReleaseMeta := strings.Split(other, ".")
+
+	selfPreReleaseLen := len(selfPreReleaseMeta)
+	otherPreReleaseLen := len(otherPreReleaseMeta)
+
+	biggestLen := otherPreReleaseLen
+	if selfPreReleaseLen > otherPreReleaseLen {
+		biggestLen = selfPreReleaseLen
+	}
+
+	// loop for parts to find the first difference
+	for i := 0; i < biggestLen; i = i + 1 {
+		partSelfPre := ""
+		if i < selfPreReleaseLen {
+			partSelfPre = selfPreReleaseMeta[i]
+		}
+
+		partOtherPre := ""
+		if i < otherPreReleaseLen {
+			partOtherPre = otherPreReleaseMeta[i]
+		}
+
+		compare := comparePart(partSelfPre, partOtherPre)
+		// if parts are equals, continue the loop
+		if compare != 0 {
+			return compare
+		}
+	}
+
+	return 0
+}
+
+// Equal tests if two versions are equal.
+func (v *Version) Equal(o *Version) bool {
+	return v.Compare(o) == 0
+}
+
+// GreaterThan tests if this version is greater than another version.
+func (v *Version) GreaterThan(o *Version) bool {
+	return v.Compare(o) > 0
+}
+
+// LessThan tests if this version is less than another version.
+func (v *Version) LessThan(o *Version) bool {
+	return v.Compare(o) < 0
+}
+
+// Metadata returns any metadata that was part of the version
+// string.
+//
+// Metadata is anything that comes after the "+" in the version.
+// For example, with "1.2.3+beta", the metadata is "beta".
+func (v *Version) Metadata() string {
+	return v.metadata
+}
+
+// Prerelease returns any prerelease data that is part of the version,
+// or blank if there is no prerelease data.
+//
+// Prerelease information is anything that comes after the "-" in the
+// version (but before any metadata). For example, with "1.2.3-beta",
+// the prerelease information is "beta".
+func (v *Version) Prerelease() string {
+	return v.pre
+}
+
+// Segments returns the numeric segments of the version as a slice of ints.
+//
+// This excludes any metadata or pre-release information. For example,
+// for a version "1.2.3-beta", segments will return a slice of
+// 1, 2, 3.
+func (v *Version) Segments() []int {
+	segmentSlice := make([]int, len(v.segments))
+	for i, v := range v.segments {
+		segmentSlice[i] = int(v)
+	}
+	return segmentSlice
+}
+
+// Segments64 returns the numeric segments of the version as a slice of int64s.
+//
+// This excludes any metadata or pre-release information. For example,
+// for a version "1.2.3-beta", segments will return a slice of
+// 1, 2, 3.
+func (v *Version) Segments64() []int64 {
+	return v.segments
+}
+
+// String returns the full version string included pre-release
+// and metadata information.
+func (v *Version) String() string {
+	var buf bytes.Buffer
+	fmtParts := make([]string, len(v.segments))
+	for i, s := range v.segments {
+		// We can ignore err here since we've pre-parsed the values in segments
+		str := strconv.FormatInt(s, 10)
+		fmtParts[i] = str
+	}
+	fmt.Fprintf(&buf, strings.Join(fmtParts, "."))
+	if v.pre != "" {
+		fmt.Fprintf(&buf, "-%s", v.pre)
+	}
+	if v.metadata != "" {
+		fmt.Fprintf(&buf, "+%s", v.metadata)
+	}
+
+	return buf.String()
+}

--- a/vendor/github.com/hashicorp/go-version/version_collection.go
+++ b/vendor/github.com/hashicorp/go-version/version_collection.go
@@ -1,0 +1,17 @@
+package version
+
+// Collection is a type that implements the sort.Interface interface
+// so that versions can be sorted.
+type Collection []*Version
+
+func (v Collection) Len() int {
+	return len(v)
+}
+
+func (v Collection) Less(i, j int) bool {
+	return v[i].LessThan(v[j])
+}
+
+func (v Collection) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}

--- a/vendor/github.com/hashicorp/go-version/version_collection_test.go
+++ b/vendor/github.com/hashicorp/go-version/version_collection_test.go
@@ -1,0 +1,46 @@
+package version
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestCollection(t *testing.T) {
+	versionsRaw := []string{
+		"1.1.1",
+		"1.0",
+		"1.2",
+		"2",
+		"0.7.1",
+	}
+
+	versions := make([]*Version, len(versionsRaw))
+	for i, raw := range versionsRaw {
+		v, err := NewVersion(raw)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		versions[i] = v
+	}
+
+	sort.Sort(Collection(versions))
+
+	actual := make([]string, len(versions))
+	for i, v := range versions {
+		actual[i] = v.String()
+	}
+
+	expected := []string{
+		"0.7.1",
+		"1.0.0",
+		"1.1.1",
+		"1.2.0",
+		"2.0.0",
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}

--- a/vendor/github.com/hashicorp/go-version/version_test.go
+++ b/vendor/github.com/hashicorp/go-version/version_test.go
@@ -1,0 +1,265 @@
+package version
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewVersion(t *testing.T) {
+	cases := []struct {
+		version string
+		err     bool
+	}{
+		{"1.2.3", false},
+		{"1.0", false},
+		{"1", false},
+		{"1.2.beta", true},
+		{"foo", true},
+		{"1.2-5", false},
+		{"1.2-beta.5", false},
+		{"\n1.2", true},
+		{"1.2.0-x.Y.0+metadata", false},
+		{"1.2.0-x.Y.0+metadata-width-hypen", false},
+		{"1.2.3-rc1-with-hypen", false},
+		{"1.2.3.4", false},
+		{"1.2.0.4-x.Y.0+metadata", false},
+		{"1.2.0.4-x.Y.0+metadata-width-hypen", false},
+		{"1.2.0-X-1.2.0+metadata~dist", false},
+		{"1.2.3.4-rc1-with-hypen", false},
+		{"1.2.3.4", false},
+		{"v1.2.3", false},
+		{"foo1.2.3", true},
+		{"1.7rc2", false},
+		{"v1.7rc2", false},
+	}
+
+	for _, tc := range cases {
+		_, err := NewVersion(tc.version)
+		if tc.err && err == nil {
+			t.Fatalf("expected error for version: %s", tc.version)
+		} else if !tc.err && err != nil {
+			t.Fatalf("error for version %s: %s", tc.version, err)
+		}
+	}
+}
+
+func TestVersionCompare(t *testing.T) {
+	cases := []struct {
+		v1       string
+		v2       string
+		expected int
+	}{
+		{"1.2.3", "1.4.5", -1},
+		{"1.2-beta", "1.2-beta", 0},
+		{"1.2", "1.1.4", 1},
+		{"1.2", "1.2-beta", 1},
+		{"1.2+foo", "1.2+beta", 0},
+		{"v1.2", "v1.2-beta", 1},
+		{"v1.2+foo", "v1.2+beta", 0},
+		{"v1.2.3.4", "v1.2.3.4", 0},
+		{"v1.2.0.0", "v1.2", 0},
+		{"v1.2.0.0.1", "v1.2", 1},
+		{"v1.2", "v1.2.0.0", 0},
+		{"v1.2", "v1.2.0.0.1", -1},
+		{"v1.2.0.0", "v1.2.0.0.1", -1},
+		{"v1.2.3.0", "v1.2.3.4", -1},
+		{"1.7rc2", "1.7rc1", 1},
+		{"1.7rc2", "1.7", -1},
+		{"1.2.0", "1.2.0-X-1.2.0+metadata~dist", 1},
+	}
+
+	for _, tc := range cases {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		actual := v1.Compare(v2)
+		expected := tc.expected
+		if actual != expected {
+			t.Fatalf(
+				"%s <=> %s\nexpected: %d\nactual: %d",
+				tc.v1, tc.v2,
+				expected, actual)
+		}
+	}
+}
+
+func TestComparePreReleases(t *testing.T) {
+	cases := []struct {
+		v1       string
+		v2       string
+		expected int
+	}{
+		{"1.2-beta.2", "1.2-beta.2", 0},
+		{"1.2-beta.1", "1.2-beta.2", -1},
+		{"1.2-beta.2", "1.2-beta.11", -1},
+		{"3.2-alpha.1", "3.2-alpha", 1},
+		{"1.2-beta.2", "1.2-beta.1", 1},
+		{"1.2-beta.11", "1.2-beta.2", 1},
+		{"1.2-beta", "1.2-beta.3", -1},
+		{"1.2-alpha", "1.2-beta.3", -1},
+		{"1.2-beta", "1.2-alpha.3", 1},
+		{"3.0-alpha.3", "3.0-rc.1", -1},
+		{"3.0-alpha3", "3.0-rc1", -1},
+		{"3.0-alpha.1", "3.0-alpha.beta", -1},
+		{"5.4-alpha", "5.4-alpha.beta", 1},
+		{"v1.2-beta.2", "v1.2-beta.2", 0},
+		{"v1.2-beta.1", "v1.2-beta.2", -1},
+		{"v3.2-alpha.1", "v3.2-alpha", 1},
+		{"v3.2-rc.1-1-g123", "v3.2-rc.2", 1},
+	}
+
+	for _, tc := range cases {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		actual := v1.Compare(v2)
+		expected := tc.expected
+		if actual != expected {
+			t.Fatalf(
+				"%s <=> %s\nexpected: %d\nactual: %d",
+				tc.v1, tc.v2,
+				expected, actual)
+		}
+	}
+}
+
+func TestVersionMetadata(t *testing.T) {
+	cases := []struct {
+		version  string
+		expected string
+	}{
+		{"1.2.3", ""},
+		{"1.2-beta", ""},
+		{"1.2.0-x.Y.0", ""},
+		{"1.2.0-x.Y.0+metadata", "metadata"},
+		{"1.2.0-metadata-1.2.0+metadata~dist", "metadata~dist"},
+	}
+
+	for _, tc := range cases {
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		actual := v.Metadata()
+		expected := tc.expected
+		if actual != expected {
+			t.Fatalf("expected: %s\nactual: %s", expected, actual)
+		}
+	}
+}
+
+func TestVersionPrerelease(t *testing.T) {
+	cases := []struct {
+		version  string
+		expected string
+	}{
+		{"1.2.3", ""},
+		{"1.2-beta", "beta"},
+		{"1.2.0-x.Y.0", "x.Y.0"},
+		{"1.2.0-x.Y.0+metadata", "x.Y.0"},
+		{"1.2.0-metadata-1.2.0+metadata~dist", "metadata-1.2.0"},
+	}
+
+	for _, tc := range cases {
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		actual := v.Prerelease()
+		expected := tc.expected
+		if actual != expected {
+			t.Fatalf("expected: %s\nactual: %s", expected, actual)
+		}
+	}
+}
+
+func TestVersionSegments(t *testing.T) {
+	cases := []struct {
+		version  string
+		expected []int
+	}{
+		{"1.2.3", []int{1, 2, 3}},
+		{"1.2-beta", []int{1, 2, 0}},
+		{"1-x.Y.0", []int{1, 0, 0}},
+		{"1.2.0-x.Y.0+metadata", []int{1, 2, 0}},
+		{"1.2.0-metadata-1.2.0+metadata~dist", []int{1, 2, 0}},
+	}
+
+	for _, tc := range cases {
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		actual := v.Segments()
+		expected := tc.expected
+		if !reflect.DeepEqual(actual, expected) {
+			t.Fatalf("expected: %#v\nactual: %#v", expected, actual)
+		}
+	}
+}
+
+func TestVersionSegments64(t *testing.T) {
+	cases := []struct {
+		version  string
+		expected []int64
+	}{
+		{"1.2.3", []int64{1, 2, 3}},
+		{"1.2-beta", []int64{1, 2, 0}},
+		{"1-x.Y.0", []int64{1, 0, 0}},
+		{"1.2.0-x.Y.0+metadata", []int64{1, 2, 0}},
+		{"1.4.9223372036854775807", []int64{1, 4, 9223372036854775807}},
+	}
+
+	for _, tc := range cases {
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		actual := v.Segments64()
+		expected := tc.expected
+		if !reflect.DeepEqual(actual, expected) {
+			t.Fatalf("expected: %#v\nactual: %#v", expected, actual)
+		}
+	}
+}
+
+func TestVersionString(t *testing.T) {
+	cases := [][]string{
+		{"1.2.3", "1.2.3"},
+		{"1.2-beta", "1.2.0-beta"},
+		{"1.2.0-x.Y.0", "1.2.0-x.Y.0"},
+		{"1.2.0-x.Y.0+metadata", "1.2.0-x.Y.0+metadata"},
+		{"1.2.0-metadata-1.2.0+metadata~dist", "1.2.0-metadata-1.2.0+metadata~dist"},
+	}
+
+	for _, tc := range cases {
+		v, err := NewVersion(tc[0])
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		actual := v.String()
+		expected := tc[1]
+		if actual != expected {
+			t.Fatalf("expected: %s\nactual: %s", expected, actual)
+		}
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,19 @@
+{
+	"comment": "",
+	"ignore": "",
+	"package": [
+		{
+			"checksumSHA1": "3xP5/nFAqTJCKmOIPKv4GadUQb4=",
+			"path": "github.com/hashicorp/go-version",
+			"revision": "4fe82ae3040f80a03d04d2cccb5606a626b8e1ee",
+			"revisionTime": "2017-11-29T15:08:20Z"
+		},
+		{
+			"checksumSHA1": "tIQCd3YGbEvxr9j2pFS8LCHt9nY=",
+			"path": "github.com/mitchellh/gox",
+			"revision": "0d65d8b8c2d1ebc3355877aec37060bee0a2f9fe",
+			"revisionTime": "2018-01-03T15:26:19Z"
+		}
+	],
+	"rootPath": "github.com/mitchellh/gox"
+}


### PR DESCRIPTION
When checking for platform compatibility, use structured version
checking instead of substring comparison.

Fixes support for go 1.10