### PR TITLE
Don't append PackagePath if it's empty

### DIFF
--- a/go.go
+++ b/go.go
@@ -112,8 +112,11 @@ func GoCrossCompile(opts *CompileOpts) error {
 		"-ldflags", opts.Ldflags,
 		"-asmflags", opts.Asmflags,
 		"-tags", opts.Tags,
-		"-o", outputPathReal,
-		opts.PackagePath)
+		"-o", outputPathReal)
+
+	if opts.PackagePath != "" {
+		args = append(args, opts.PackagePath)
+	}
 
 	_, err = execGo(opts.GoCmd, env, chdir, args...)
 	return err


### PR DESCRIPTION
Including the `PackagePath` in the command when it's empty has strange side effects. 

In my case my `-ldflags "-X main.version=1.2.3"` seemed to be ignored. (The `version` field in my `main` did not get populated).

This PR fixes the bug.