### PR TITLE
Configurable C cross-compilers for each platform

### DIFF
--- a/ccrosscompiler_flag.go
+++ b/ccrosscompiler_flag.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	osArchPos    = 0
+	cCompilerPos = 1
+)
+
+// CCrossCompilerFlag stores the platforms and their selected C cross-compilers.
+type CCrossCompilerFlag struct {
+	selected map[string]string
+	raw      string
+}
+
+// Set parses the input comma-separated list of platforms and compilers.
+// Valid format: "linux/arm=arm-linux-gnueabi-gcc-6"
+func (c *CCrossCompilerFlag) Set(s string) error {
+	pairs := strings.Split(s, ",")
+	c.selected = make(map[string]string, len(pairs))
+
+	for _, pair := range pairs {
+		elems := strings.Split(pair, "=")
+		if len(elems) != 2 {
+			return fmt.Errorf("invalid format: requires two elements separated by =")
+		}
+		c.selected[elems[osArchPos]] = elems[cCompilerPos]
+	}
+
+	c.raw = s
+	return nil
+}
+
+func (c *CCrossCompilerFlag) String() string {
+	return c.raw
+}
+
+func (c *CCrossCompilerFlag) Get() map[string]string {
+	return c.selected
+}

--- a/go.go
+++ b/go.go
@@ -21,16 +21,17 @@ type OutputTemplateData struct {
 }
 
 type CompileOpts struct {
-	PackagePath string
-	Platform    Platform
-	OutputTpl   string
-	Ldflags     string
-	Gcflags     string
-	Asmflags    string
-	Tags        string
-	Cgo         bool
-	Rebuild     bool
-	GoCmd       string
+	PackagePath    string
+	Platform       Platform
+	OutputTpl      string
+	Ldflags        string
+	Gcflags        string
+	Asmflags       string
+	Tags           string
+	Cgo            bool
+	Rebuild        bool
+	GoCmd          string
+	CCrossCompiler string
 }
 
 // GoCrossCompile
@@ -49,6 +50,9 @@ func GoCrossCompile(opts *CompileOpts) error {
 	// If cgo is enabled then set that env var
 	if opts.Cgo {
 		env = append(env, "CGO_ENABLED=1")
+		if opts.CCrossCompiler != "" {
+			env = append(env, "CC="+opts.CCrossCompiler)
+		}
 	} else {
 		env = append(env, "CGO_ENABLED=0")
 	}


### PR DESCRIPTION
Right now if `CC` is passed to `gox` C cross-compiler is changed for all platforms. However, it is possible that some platforms require different C compilers.

A new flag named `-c-cross-compilers` is added. From now on it is possible to set different C cross-compilers for each platforms by setting the flag. Platforms which does not have any special compiler use the default provided by the host.

### Format

Name of the platform and the compiler is separated by `=`. To configure multiple platform and compilers pairs more can be added separated by comma.
```
{ platformname }={ compiler }
{ platformname1 }={ compiler1 },{ platformname1 }={ compiler1 }
```

### Example usage
```
gox -os=linux -arch="arm amd64" -c-cross-compilers="linux/arm=arm-linux-gnueabi-gcc-6"
```
