### PR TITLE
Fixed minor typo in SupportedPlatforms() function

### DIFF
--- a/platform.go
+++ b/platform.go
@@ -145,5 +145,5 @@ func SupportedPlatforms(v string) []Platform {
 	}
 
 	// Assume latest
-	return Platforms_1_9
+	return PlatformsLatest
 }


### PR DESCRIPTION
In case of future Go releases above 1.10, the code would previously return the 1.9 instead of the defined latest list (currently 1.10 which is identical).