### PR TITLE
Allow -mod passthrough to the go compiler.

### DIFF
--- a/go.go
+++ b/go.go
@@ -28,6 +28,7 @@ type CompileOpts struct {
 	Gcflags     string
 	Asmflags    string
 	Tags        string
+	ModMode     string
 	Cgo         bool
 	Rebuild     bool
 	GoCmd       string
@@ -106,6 +107,9 @@ func GoCrossCompile(opts *CompileOpts) error {
 	args := []string{"build"}
 	if opts.Rebuild {
 		args = append(args, "-a")
+	}
+	if opts.ModMode != "" {
+		args = append(args, "-mod", opts.ModMode)
 	}
 	args = append(args,
 		"-gcflags", opts.Gcflags,


### PR DESCRIPTION
This allows for telling go 1.11 + to continue to use vendored dependencies or to not modify the go.mod by passing `-vendor readonly`.