### PR TITLE
Fix: Execute version check in tempdir

### DIFF
--- a/go.go
+++ b/go.go
@@ -187,7 +187,7 @@ func GoVersion() (string, error) {
 	}
 
 	// Execute and read the version, which will be the only thing on stdout.
-	return execGo("go", nil, "", "run", sourcePath)
+	return execGo("go", nil, td, "run", sourcePath)
 }
 
 // GoVersionParts parses the version numbers from the version itself


### PR DESCRIPTION
In order not to have to deal with `go mod` issues appearing when executing the version check in a directory having private Go modules but no valid authentication to update them execute the version check in the tempdir already created.

That way the `go run` command will not detect the `go.mod` file of the program to build later on and therefore will not try to fetch the private modules which it can't fetch.