### PR TITLE
Support go1.13 -trimpath option

### DIFF
--- a/go.go
+++ b/go.go
@@ -31,6 +31,7 @@ type CompileOpts struct {
 	ModMode     string
 	Cgo         bool
 	Rebuild     bool
+	TrimPath    bool
 	GoCmd       string
 }
 
@@ -107,6 +108,9 @@ func GoCrossCompile(opts *CompileOpts) error {
 	args := []string{"build"}
 	if opts.Rebuild {
 		args = append(args, "-a")
+	}
+	if opts.TrimPath {
+		args = append(args, "-trimpath")
 	}
 	if opts.ModMode != "" {
 		args = append(args, "-mod", opts.ModMode)

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func realMain() int {
 	var tags string
 	var verbose bool
 	var flagGcflags, flagAsmflags string
-	var flagCgo, flagRebuild, flagListOSArch bool
+	var flagCgo, flagRebuild, flagTrimPath, flagListOSArch bool
 	var flagGoCmd string
 	var modMode string
 	flags := flag.NewFlagSet("gox", flag.ExitOnError)
@@ -43,6 +43,7 @@ func realMain() int {
 	flags.BoolVar(&verbose, "verbose", false, "verbose")
 	flags.BoolVar(&flagCgo, "cgo", false, "")
 	flags.BoolVar(&flagRebuild, "rebuild", false, "")
+	flags.BoolVar(&flagTrimPath, "trimpath", false, "")
 	flags.BoolVar(&flagListOSArch, "osarch-list", false, "")
 	flags.StringVar(&flagGcflags, "gcflags", "", "")
 	flags.StringVar(&flagAsmflags, "asmflags", "", "")
@@ -161,6 +162,7 @@ func realMain() int {
 					ModMode:     modMode,
 					Cgo:         flagCgo,
 					Rebuild:     flagRebuild,
+					TrimPath:    flagTrimPath,
 					GoCmd:       flagGoCmd,
 				}
 
@@ -221,6 +223,7 @@ Options:
   -parallel=-1        Amount of parallelism, defaults to number of CPUs
   -gocmd="go"         Build command, defaults to Go
   -rebuild            Force rebuilding of package that were up to date
+  -trimpath			  Remove all file system paths from the resulting executable
   -verbose            Verbose mode
 
 Output path template:


### PR DESCRIPTION
Quick change to allow passing through the new -trimpath build option added in Go 1.13.