### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To install Gox, please use `go get`. We tag versions so feel free to
 checkout that tag and compile.
 
 ```
-$ go install github.com/mitchellh/gox
+$ go install github.com/mitchellh/gox@latest
 ...
 $ gox -h
 ...

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To install Gox, please use `go get`. We tag versions so feel free to
 checkout that tag and compile.
 
 ```
-$ go get github.com/mitchellh/gox
+$ go install github.com/mitchellh/gox
 ...
 $ gox -h
 ...


### PR DESCRIPTION
Replace `go get` with `go install` since get is no longer supported.
```PS C:\Users\Alexander> go get github.com/mitchellh/gox
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.